### PR TITLE
fix: ComponentID

### DIFF
--- a/pkg/wire/tun/wire_windows.go
+++ b/pkg/wire/tun/wire_windows.go
@@ -28,7 +28,7 @@ func NewTunWire(name string, addr string) (wire.Wire, error) {
 	config := water.Config{
 		DeviceType: water.TUN,
 		PlatformSpecificParams: water.PlatformSpecificParams{
-			ComponentID: "tap0901",
+			ComponentID: "root\\tap0901",
 			Network:     addr,
 		},
 	}


### PR DESCRIPTION
Fix windows specific error:
```
tunwire: 2023/03/29 23:36:54 wire_windows.go:37: Failed to find the tap device in registry with specified ComponentId 'tap0901', TAP driver may be not installed
```

See https://github.com/songgao/water/pull/91